### PR TITLE
README: Put path argument last in example, as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ Run:
 
 ```bash
 poetry run icons-asset-generator \
-    --path "./Asset-Package_04302022" \
     --filename-includes _48 \
     --filename-excludes Dark \
     --image-name-remove Light Arch_ Res_ _48 . - _  \
     --library-name-remove  . - _ \
+    --path "./Asset-Package_04302022" \
     diagrams.net
 ```
 


### PR DESCRIPTION
I was getting the following error when following the example in the README:

```
icons-asset-generator: error: the following arguments are required: TARGET
```

This appears to be because as noted earlier in the README the `--path` argument needs to be passed last when there are any multi-argument parameters (like `--image-name-remove` and `--library-name-remove` in the example)